### PR TITLE
Fix Vercel deployment output directory configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "framework": "vite",
   "buildCommand": "npm run build",
-  "outputDirectory": "build",
+  "outputDirectory": "dist",
   "routes": [
     { "handle": "filesystem" },
     { "src": "/(.*)", "dest": "/index.html" }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -57,7 +57,7 @@
     },
     build: {
       target: 'esnext',
-      outDir: 'build',
+      outDir: 'dist',
     },
     server: {
       port: 3000,


### PR DESCRIPTION
## Summary
- update Vercel config to expect the dist build output produced by Vite
- align the Vite build outDir with the new dist deployment folder

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e426120fe083309b9f62a04fbc33c4